### PR TITLE
Don't continue without the `confirm=1` parameter

### DIFF
--- a/src/Task/PruneSelectedORMTablesTask.php
+++ b/src/Task/PruneSelectedORMTablesTask.php
@@ -48,6 +48,8 @@ final class PruneSelectedORMTablesTask extends BuildTask
 
         if (is_null($request->getVar('confirm'))) {
             echo 'Are you sure? Please add ?confirm=1 to the URL to confirm.' . PHP_EOL;
+
+            return;
         }
 
         DB::get_conn()->withTransaction(function (): void {


### PR DESCRIPTION
Looks like the `return` was missing, so not having the parameter will not stop the process 😬 