### PR TITLE
Add ability to truncate specified db tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ Name: app_pruner
 ---
 Cambis\SilverstripePruner\Task\PruneSelectedORMTablesTask:
   # List the fqn names of the DataObjects you want to truncate
-  truncated_tables:
+  truncated_classes:
     - My\Record\To\Truncate
+  # Any extra tables such as those from silverstripe/versioned etc.
+  truncated_tables:
+    - Truncate_Stage
+    - Truncate_Live
+    - Truncate_Versions
   # Defaults to false, add this line if you want to run the task in a production environment
   can_run_in_production: true
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Cambis\SilverstripePruner\Task\PruneSelectedORMTablesTask:
     - My\Record\To\Truncate
   # Any extra tables such as those from silverstripe/versioned etc.
   truncated_tables:
-    - Truncate_Stage
     - Truncate_Live
     - Truncate_Versions
   # Defaults to false, add this line if you want to run the task in a production environment

--- a/tests/php/Task/PruneSelectedORMTablesTaskTest.php
+++ b/tests/php/Task/PruneSelectedORMTablesTaskTest.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use const PHP_EOL;
 
 final class PruneSelectedORMTablesTaskTest extends SapphireTest
@@ -35,9 +36,18 @@ final class PruneSelectedORMTablesTaskTest extends SapphireTest
             'truncated_classes',
             [TestRecord::class]
         );
+
+        Config::modify()->set(
+            PruneSelectedORMTablesTask::class,
+            'truncated_tables',
+            ['TestRecord_Foo']
+        );
+
+        DB::query('DROP TABLE IF EXISTS TestRecord_Foo;');
+        DB::query('CREATE TABLE TestRecord_Foo (Bar varchar(255) not null);');
     }
 
-    public function testRun(): void
+    public function testTruncateClass(): void
     {
         $record = TestRecord::create();
         $record->write();
@@ -52,6 +62,20 @@ final class PruneSelectedORMTablesTaskTest extends SapphireTest
         $this->assertCount(0, TestRecord::get());
     }
 
+    public function testTruncateTable(): void
+    {
+        DB::query('INSERT INTO "TestRecord_Foo" ("Bar") VALUES (\'Baz\');');
+
+        $this->assertSame(1, (int) DB::query('SELECT COUNT(*) FROM TestRecord_Foo;')->value());
+
+        $task = PruneSelectedORMTablesTask::create();
+        $task->run(new HTTPRequest('GET', '/', [
+            'confirm' => 1,
+        ]));
+
+        $this->assertSame(0, (int) DB::query('SELECT COUNT(*) FROM TestRecord_Foo;')->value());
+    }
+
     public function testRunInProduction(): void
     {
         $director = new class extends Director implements TestOnly {
@@ -63,14 +87,14 @@ final class PruneSelectedORMTablesTaskTest extends SapphireTest
 
         Injector::inst()->registerService($director, Director::class);
 
-        $this->expectOutputString('This task cannot be run in a production environment!' . PHP_EOL);
+        $this->expectOutputString('🚨 This task cannot be run in a production environment! 🚨' . PHP_EOL);
         $task = PruneSelectedORMTablesTask::create();
         $task->run(new HTTPRequest('GET', '/'));
     }
 
     public function testRunWithoutConfirmation(): void
     {
-        $this->expectOutputString('Are you sure? Please add ?confirm=1 to the URL to confirm.' . PHP_EOL);
+        $this->expectOutputString('⚠️ Are you sure? Please add ?confirm=1 to the URL to confirm. ⚠️' . PHP_EOL);
         $task = PruneSelectedORMTablesTask::create();
         $task->run(new HTTPRequest('GET', '/'));
     }


### PR DESCRIPTION
## Description ✍️

Allow the user to truncate tables, this is can be achieved using the new configuration property `truncated_tables`.

## Fixes 🐛

- #3 

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](../CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](../CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](../CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](../CONTRIBUTING.md#making-a-pull-request-).
